### PR TITLE
Add Ariyo-style CLI chatbot with intents, persona, memory, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Ariyo-Style CLI Chatbot
+
+A conversation-only chatbot with a warm, respectful tone and session memory.
+
+## How to run
+
+```bash
+python main.py
+```
+
+## How to run tests
+
+```bash
+python -m unittest
+```
+
+## How to add a new intent and response rule
+
+1. Add a new intent name and keyword rules in `bot/intents.py` inside `IntentDetector.intent_rules`.
+2. Add a response template in `bot/persona.py` inside `AriyoPersona.responses`, or add special handling in
+   `AriyoPersona.generate_response` if the intent needs dynamic content.
+3. Add or update tests in `tests/test_intents.py` to cover the new intent.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Ariyo-style chatbot package."""

--- a/bot/engine.py
+++ b/bot/engine.py
@@ -1,0 +1,45 @@
+"""Chat engine orchestrating intents, memory, and persona."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .intents import IntentDetector, IntentResult
+from .logger import ChatLogger
+from .memory import SessionMemory
+from .persona import AriyoPersona
+
+
+@dataclass
+class ChatEngine:
+    """Coordinator for chat interactions."""
+
+    detector: IntentDetector
+    persona: AriyoPersona
+    memory: SessionMemory
+    logger: ChatLogger
+
+    def handle_message(self, user_text: str) -> tuple[str, IntentResult]:
+        """Handle a user message and return a response with intent info."""
+        intent_result = self.detector.detect(user_text)
+
+        if intent_result.intent == "reset_memory":
+            self.memory.reset()
+
+        response = self.persona.generate_response(
+            intent=intent_result.intent,
+            user_text=user_text,
+            memory=self.memory,
+            confidence=intent_result.confidence,
+        )
+
+        self.memory.add_user_message(user_text)
+        self.memory.add_bot_message(response)
+
+        self.logger.log_turn(
+            user_text=user_text,
+            intent=intent_result.intent,
+            confidence=intent_result.confidence,
+            response=response,
+        )
+
+        return response, intent_result

--- a/bot/intents.py
+++ b/bot/intents.py
@@ -1,0 +1,79 @@
+"""Intent detection and scoring."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class IntentResult:
+    """Result of intent detection."""
+
+    intent: str
+    confidence: float
+
+
+class IntentDetector:
+    """Rule-based intent detector with lightweight scoring."""
+
+    def __init__(self) -> None:
+        self.intent_rules: Dict[str, List[Tuple[List[str], float]]] = {
+            "greetings": [
+                (["hello", "hi", "hey", "good morning", "good afternoon", "good evening"], 0.6),
+                (["howdy", "yo"], 0.3),
+            ],
+            "gratitude": [
+                (["thanks", "thank you", "appreciate", "grateful"], 0.8),
+                (["cheers"], 0.3),
+            ],
+            "help": [
+                (["help", "what can you do", "how do you work", "commands"], 0.8),
+                (["guide", "assist", "support"], 0.4),
+            ],
+            "smalltalk": [
+                (["how are you", "how's it going", "how are things"], 0.6),
+                (["tell me about yourself", "who are you"], 0.5),
+                (["what's up", "whats up", "sup"], 0.4),
+            ],
+            "ask_time": [
+                (["time", "what time", "current time"], 0.7),
+                (["clock"], 0.3),
+            ],
+            "ask_date": [
+                (["date", "what date", "what day"], 0.7),
+                (["day is it", "calendar"], 0.3),
+            ],
+            "goodbye": [
+                (["bye", "goodbye", "see you", "later"], 0.7),
+                (["exit", "quit", "farewell"], 0.6),
+            ],
+            "reset_memory": [
+                (["reset memory", "clear memory", "forget this", "wipe memory"], 0.9),
+            ],
+        }
+
+    def detect(self, text: str) -> IntentResult:
+        """Detect the best intent for the given text."""
+        normalized = " ".join(text.lower().strip().split())
+        if not normalized:
+            return IntentResult(intent="fallback", confidence=0.0)
+
+        best_intent = "fallback"
+        best_confidence = 0.0
+
+        for intent, rules in self.intent_rules.items():
+            score = 0.0
+            max_weight = 0.0
+            for phrases, weight in rules:
+                max_weight = max(max_weight, weight)
+                if any(phrase in normalized for phrase in phrases):
+                    score += weight
+            confidence = min(1.0, score / max_weight) if max_weight else 0.0
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_intent = intent
+
+        if best_confidence < 0.35:
+            return IntentResult(intent="fallback", confidence=best_confidence)
+
+        return IntentResult(intent=best_intent, confidence=round(best_confidence, 2))

--- a/bot/logger.py
+++ b/bot/logger.py
@@ -1,0 +1,28 @@
+"""File logging for chat turns."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass
+class ChatLogger:
+    """Simple file logger that appends chat turns with timestamps."""
+
+    log_dir: Path = Path("logs")
+    log_file: str = "chat.log"
+
+    def __post_init__(self) -> None:
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def log_turn(self, user_text: str, intent: str, confidence: float, response: str) -> None:
+        """Log a single conversation turn."""
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        log_path = self.log_dir / self.log_file
+        line = (
+            f"[{timestamp}] user={user_text!r} intent={intent} "
+            f"confidence={confidence:.2f} bot={response!r}\n"
+        )
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(line)

--- a/bot/memory.py
+++ b/bot/memory.py
@@ -1,0 +1,41 @@
+"""Session memory for the chatbot."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, List
+
+
+@dataclass
+class SessionMemory:
+    """Bounded in-memory store for recent conversation turns."""
+
+    max_messages: int = 20
+    user_messages: Deque[str] = field(init=False)
+    bot_messages: Deque[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Initialize deques with the configured max length."""
+        self.user_messages = deque(maxlen=self.max_messages)
+        self.bot_messages = deque(maxlen=self.max_messages)
+
+    def add_user_message(self, message: str) -> None:
+        """Add a user message to memory."""
+        self.user_messages.append(message)
+
+    def add_bot_message(self, message: str) -> None:
+        """Add a bot message to memory."""
+        self.bot_messages.append(message)
+
+    def reset(self) -> None:
+        """Clear all stored messages."""
+        self.user_messages.clear()
+        self.bot_messages.clear()
+
+    def recent_user_messages(self) -> List[str]:
+        """Return a list of recent user messages."""
+        return list(self.user_messages)
+
+    def recent_bot_messages(self) -> List[str]:
+        """Return a list of recent bot messages."""
+        return list(self.bot_messages)

--- a/bot/persona.py
+++ b/bot/persona.py
@@ -1,0 +1,50 @@
+"""Persona and response templates."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from .memory import SessionMemory
+
+
+class AriyoPersona:
+    """Ariyo-style response generator."""
+
+    def __init__(self) -> None:
+        self.responses: Dict[str, str] = {
+            "greetings": "Hello! I'm Ariyo. How can I help today?",
+            "help": (
+                "I can chat, answer simple questions, tell you the time/date, "
+                "and reset our session memory. Try: 'what time is it?' or 'reset memory'."
+            ),
+            "smalltalk": "I'm doing well, thanks for asking. How can I support you?",
+            "gratitude": "You're welcome. Happy to help.",
+            "goodbye": "Take care! If you need anything, I'm here.",
+            "reset_memory": "All set. I've cleared our session memory.",
+            "fallback": "I'm not fully sure I got that. Could you rephrase?",
+        }
+
+    def generate_response(
+        self,
+        intent: str,
+        user_text: str,
+        memory: SessionMemory,
+        confidence: float,
+        now: datetime | None = None,
+    ) -> str:
+        """Generate a response given an intent and context."""
+        if intent == "ask_time":
+            timestamp = (now or datetime.now()).strftime("%H:%M")
+            return f"It's {timestamp} right now."
+        if intent == "ask_date":
+            date_str = (now or datetime.now()).strftime("%A, %B %d, %Y")
+            return f"Today is {date_str}."
+        if intent == "smalltalk" and "tell me more" in user_text.lower():
+            return (
+                "I'm Ariyo, your friendly chat companion. "
+                "I keep things simple, respectful, and helpful."
+            )
+        if intent == "fallback" and confidence > 0.0:
+            return "I might be a bit off. Can you say that another way?"
+
+        return self.responses.get(intent, self.responses["fallback"])

--- a/main.py
+++ b/main.py
@@ -1,0 +1,43 @@
+"""CLI entry point for the Ariyo-style chatbot."""
+from __future__ import annotations
+
+from bot.engine import ChatEngine
+from bot.intents import IntentDetector
+from bot.logger import ChatLogger
+from bot.memory import SessionMemory
+from bot.persona import AriyoPersona
+
+
+def main() -> None:
+    """Run the CLI chat loop."""
+    engine = ChatEngine(
+        detector=IntentDetector(),
+        persona=AriyoPersona(),
+        memory=SessionMemory(max_messages=20),
+        logger=ChatLogger(),
+    )
+
+    print("Ariyo: Hello! I'm Ariyo, your chat companion.")
+    print("Try: 'what time is it?', 'reset memory', or 'tell me about yourself'.")
+    print("Type 'exit' or 'quit' to leave.\n")
+
+    while True:
+        user_text = input("You: ").strip()
+        if not user_text:
+            print("Ariyo: I'm listening. Share a thought or ask a question.")
+            continue
+
+        normalized = user_text.lower()
+        if normalized in {"exit", "quit"}:
+            print("Ariyo: Take care! If you need anything, I'm here.")
+            break
+
+        response, intent = engine.handle_message(user_text)
+        print(f"Ariyo: {response}")
+
+        if intent.intent == "goodbye":
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for Ariyo chatbot."""

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,0 +1,57 @@
+"""Tests for intent detection."""
+import unittest
+
+from bot.intents import IntentDetector
+
+
+class TestIntentDetector(unittest.TestCase):
+    def setUp(self) -> None:
+        self.detector = IntentDetector()
+
+    def test_greeting_intent(self) -> None:
+        result = self.detector.detect("Hello there")
+        self.assertEqual(result.intent, "greetings")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_help_intent(self) -> None:
+        result = self.detector.detect("Can you help me?")
+        self.assertEqual(result.intent, "help")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_smalltalk_intent(self) -> None:
+        result = self.detector.detect("How are you today?")
+        self.assertEqual(result.intent, "smalltalk")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_time_intent(self) -> None:
+        result = self.detector.detect("What time is it?")
+        self.assertEqual(result.intent, "ask_time")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_date_intent(self) -> None:
+        result = self.detector.detect("What's the date today?")
+        self.assertEqual(result.intent, "ask_date")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_gratitude_intent(self) -> None:
+        result = self.detector.detect("Thanks for the help")
+        self.assertEqual(result.intent, "gratitude")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_goodbye_intent(self) -> None:
+        result = self.detector.detect("Goodbye for now")
+        self.assertEqual(result.intent, "goodbye")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_reset_memory_intent(self) -> None:
+        result = self.detector.detect("reset memory")
+        self.assertEqual(result.intent, "reset_memory")
+        self.assertGreaterEqual(result.confidence, 0.5)
+
+    def test_fallback_intent(self) -> None:
+        result = self.detector.detect("abracadabra")
+        self.assertEqual(result.intent, "fallback")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,30 @@
+"""Tests for session memory."""
+import unittest
+
+from bot.memory import SessionMemory
+
+
+class TestSessionMemory(unittest.TestCase):
+    def test_memory_max_length(self) -> None:
+        memory = SessionMemory(max_messages=3)
+        for i in range(5):
+            memory.add_user_message(f"user-{i}")
+            memory.add_bot_message(f"bot-{i}")
+
+        self.assertEqual(len(memory.recent_user_messages()), 3)
+        self.assertEqual(len(memory.recent_bot_messages()), 3)
+        self.assertEqual(memory.recent_user_messages()[0], "user-2")
+        self.assertEqual(memory.recent_bot_messages()[0], "bot-2")
+
+    def test_reset_clears_memory(self) -> None:
+        memory = SessionMemory(max_messages=3)
+        memory.add_user_message("hello")
+        memory.add_bot_message("hi")
+        memory.reset()
+
+        self.assertEqual(memory.recent_user_messages(), [])
+        self.assertEqual(memory.recent_bot_messages(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a conversation-only, stateful CLI chatbot with a warm "Ariyo" persona and no external dependencies.
- Keep session context (last 20 user and bot messages) and allow explicit memory reset via a command.
- Implement deterministic, rule-based intent detection with lightweight confidence scoring for common conversational intents.
- Offer a simple developer workflow and unit tests to validate intent detection and memory behavior.

### Description
- Add a CLI entrypoint in `main.py` and a coordinating `ChatEngine` in `bot/engine.py` that orchestrates intent detection, response generation, memory updates, and logging.
- Implement `IntentDetector` in `bot/intents.py` with keyword/phrase rules and a revised confidence computation, and add `IntentResult` as the detection output.
- Provide a bounded `SessionMemory` in `bot/memory.py` (configurable `max_messages` with `__post_init__` deques) and `AriyoPersona` in `bot/persona.py` with templates and dynamic handling for time/date.
- Add file logging in `bot/logger.py` that appends turns to `logs/chat.log`, plus unit tests in `tests/test_intents.py` and `tests/test_memory.py`, and documentation in `README.md`.

### Testing
- Ran the full test suite with `python -m unittest` which executed the intent and memory tests; all tests passed (`11 tests, OK`).
- Included automated tests: `tests/test_intents.py` verifies mapping of example phrases to intents and confidence thresholds, and `tests/test_memory.py` checks memory max length and reset behavior.
- Test runs initially surfaced and were used to fix issues in `bot/memory.py` and scoring rules in `bot/intents.py`, after which the suite passed successfully.
- No external services or network calls were used during tests, ensuring deterministic execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2a6256e08332b7da1cc20076f36b)